### PR TITLE
Don't include whitespace (or apostrophe) character in search term

### DIFF
--- a/webExtension/app/lib/mouseObserver.js
+++ b/webExtension/app/lib/mouseObserver.js
@@ -60,7 +60,7 @@ function _getWordUnderCursor(event) {
 
     //Find the begin of the word (space)
     while (i > 0 && data.charAt(i).match(/[\w\u00C0-\u00ff]+/)) { --i; };
-    begin = i;
+    begin = i + 1;
 
     //Find the end of the word
     i = offset;


### PR DESCRIPTION
Fixes #8 