### PR TITLE
Make extension description localizable

### DIFF
--- a/webExtension/app/_locales/de/messages.json
+++ b/webExtension/app/_locales/de/messages.json
@@ -4,7 +4,7 @@
     "description": "Label for the bottom-page menu."
   },
   "extensionDescription": {
-    "message": "A browser extension which is translating words in Rumantsch when hovering with the mouse over the word.",
+    "message": "Pledarix übersetzt das Wort einer Webseite, das sich gerade hinter dem Mauszeiger befindet, wahlweise in ein rätoromanisches Idiom, Französisch, Italienisch oder Englisch.",
     "description": "The description of the extension shown on the extensions page in the browser"
   }
 }

--- a/webExtension/app/_locales/de/messages.json
+++ b/webExtension/app/_locales/de/messages.json
@@ -2,5 +2,9 @@
   "selectSearchDirection": {
     "message": "Suchrichtung",
     "description": "Label for the bottom-page menu."
+  },
+  "extensionDescription": {
+    "message": "A browser extension which is translating words in Rumantsch when hovering with the mouse over the word.",
+    "description": "The description of the extension shown on the extensions page in the browser"
   }
 }

--- a/webExtension/app/_locales/rm/messages.json
+++ b/webExtension/app/_locales/rm/messages.json
@@ -4,7 +4,7 @@
     "description": "Label for the bottom-page menu."
   },
   "extensionDescription": {
-    "message": "A browser extension which is translating words in Rumantsch when hovering with the mouse over the word.",
+    "message": "Pledarix translatescha il pled dad ina pagina d’internet che sa chatta gist davos il mussader da la mieur – tut tenor preferenza - en in dals idioms rumantschs, tudestg, talian, franzos ed englais.",
     "description": "The description of the extension shown on the extensions page in the browser"
   }
 }

--- a/webExtension/app/_locales/rm/messages.json
+++ b/webExtension/app/_locales/rm/messages.json
@@ -2,5 +2,9 @@
   "selectSearchDirection": {
     "message": "Direcziun per la tschertga",
     "description": "Label for the bottom-page menu."
+  },
+  "extensionDescription": {
+    "message": "A browser extension which is translating words in Rumantsch when hovering with the mouse over the word.",
+    "description": "The description of the extension shown on the extensions page in the browser"
   }
 }

--- a/webExtension/app/manifest.json
+++ b/webExtension/app/manifest.json
@@ -1,5 +1,6 @@
 {
   "manifest_version": 2,
+  "description": "__MSG_extensionDescription__",
   "applications": {
     "gecko": {
       "id": "pledarix@rumantsch.ch",


### PR DESCRIPTION
This changes allows to define translations for each supported language for the description of the extension.